### PR TITLE
Github moved 'access_token' to the Authorization header

### DIFF
--- a/lib/Dancer2/Plugin/Auth/OAuth/Provider/Github.pm
+++ b/lib/Dancer2/Plugin/Auth/OAuth/Provider/Github.pm
@@ -19,8 +19,8 @@ sub post_process {
     my $session_data = $session->read('oauth');
 
     my $resp = $self->{ua}->request(
-        GET $self->provider_settings->{urls}{user_info}."?access_token=".
-            $session_data->{github}{access_token}
+        GET $self->provider_settings->{urls}{user_info},
+        'Authorization' => 'token '.$session_data->{github}{access_token}
     );
 
     if( $resp->is_success ) {


### PR DESCRIPTION
Please check:
"Deprecating API authentication through query parameters"

https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/